### PR TITLE
Added support for using CloudFront as the CDN alongside S3

### DIFF
--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -153,10 +153,10 @@ class AwsS3Provider extends Provider implements ProviderInterface{
             // Initialize the batch builder
             $this->setBatchBuilder(
                 BatchBuilder::factory()
-                    ->transferCommands($this->threshold)
-                    ->autoFlushAt($this->threshold)
-                    ->keepHistory()
-                    ->build()
+                ->transferCommands($this->threshold)
+                ->autoFlushAt($this->threshold)
+                ->keepHistory()
+                ->build()
             );
 
         }catch (\Exception $e){

--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -193,7 +193,7 @@ class AwsS3Provider extends Provider implements ProviderInterface{
                 $this->batch->add($this->s3_client->getCommand('PutObject', [
 
                     'Bucket'    => $this->getBucket(), // the bucket name
-                    'Key'       => $file->getPathName(), // the path of the file on the server (CDN)
+                    'Key'       => str_replace('\\', '/', $file->getPathName()), // the path of the file on the server (CDN)
                     'Body'      => fopen($file->getRealPath(), 'r'), // the path of the path locally
                     'ACL'       => $this->acl, // the permission of the file
 

--- a/src/Vinelab/Cdn/Providers/Contracts/ProviderInterface.php
+++ b/src/Vinelab/Cdn/Providers/Contracts/ProviderInterface.php
@@ -14,6 +14,10 @@ interface ProviderInterface{
 
     public function getUrl();
 
+    public function getCloudFront();
+
+    public function getCloudFrontUrl();
+
     public function getBucket();
 
     public function setS3Client($s3_client);

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -17,7 +17,7 @@ return [
     |
     */
 
-    'bypass' => false,
+    'bypass' => $app->environment('local') ? false : false,
 
     /*
     |--------------------------------------------------------------------------
@@ -34,10 +34,10 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | CDN URL
+    | S3 URL
     |--------------------------------------------------------------------------
     |
-    | Set your CDN url, [without the bucket name]
+    | Set your S3 url, [without your bucket name]
     |
     */
     'url' => 'https://s3.amazonaws.com',
@@ -73,8 +73,8 @@ return [
             's3' => [
 
                 'credentials' => [
-                    'key'       => '',
-                    'secret'    => '',
+                    'key'       => env('S3_ACCESS_KEY'),
+                    'secret'    => env('S3_SECRET_KEY'),
                 ],
 
                 /*
@@ -92,7 +92,7 @@ return [
                 |
                 */
                 'buckets' => [
-                    'bucket-name' => '*',
+                    'spareskills' => '*',
                     //        'your-js-bucket-name-here'   =>  ['public/js'],
                     //        'your-css-bucket-name-here'  =>  ['public/css'],
                 ],
@@ -108,7 +108,21 @@ return [
                 | predefined grants: private, public-read, public-read-write, authenticated-read
                 | bucket-owner-read, bucket-owner-full-control, log-delivery-write
                 */
-                'acl' => 'public-read'
+                'acl' => 'public-read',
+
+                /*
+                |--------------------------------------------------------------------------
+                | Use CloudFront as the CDN
+                |--------------------------------------------------------------------------
+                |
+                | Amazon S3 can be linked to CloudFront through distributions. This allows
+                | the files in your S3 buckets to be served from a number of global
+                | locations to achieve low latency and faster page load times.
+                */
+                'cloudfront' => [
+                    'use'       => false,
+                    'cdn_url'   => '',
+                ],
 
             ],
 

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -108,7 +108,21 @@ return [
                 | predefined grants: private, public-read, public-read-write, authenticated-read
                 | bucket-owner-read, bucket-owner-full-control, log-delivery-write
                 */
-                'acl' => 'public-read'
+                'acl' => 'public-read',
+
+                /*
+                |--------------------------------------------------------------------------
+                | Use CloudFront as the CDN
+                |--------------------------------------------------------------------------
+                |
+                | Amazon S3 can be linked to CloudFront through distributions. This allows
+                | the files in your S3 buckets to be served from a number of global
+                | locations to achieve low latency and faster page load times.
+                */
+                'cloudfront' => [
+                    'use'       => false,
+                    'cdn_url'   => '',
+                ],
 
             ],
 

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -17,7 +17,7 @@ return [
     |
     */
 
-    'bypass' => $app->environment('local') ? false : false,
+    'bypass' => false,
 
     /*
     |--------------------------------------------------------------------------
@@ -34,10 +34,10 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | S3 URL
+    | CDN URL
     |--------------------------------------------------------------------------
     |
-    | Set your S3 url, [without your bucket name]
+    | Set your CDN url, [without the bucket name]
     |
     */
     'url' => 'https://s3.amazonaws.com',
@@ -73,8 +73,8 @@ return [
             's3' => [
 
                 'credentials' => [
-                    'key'       => env('S3_ACCESS_KEY'),
-                    'secret'    => env('S3_SECRET_KEY'),
+                    'key'       => '',
+                    'secret'    => '',
                 ],
 
                 /*
@@ -92,7 +92,7 @@ return [
                 |
                 */
                 'buckets' => [
-                    'spareskills' => '*',
+                    'bucket-name' => '*',
                     //        'your-js-bucket-name-here'   =>  ['public/js'],
                     //        'your-css-bucket-name-here'  =>  ['public/css'],
                 ],
@@ -108,21 +108,7 @@ return [
                 | predefined grants: private, public-read, public-read-write, authenticated-read
                 | bucket-owner-read, bucket-owner-full-control, log-delivery-write
                 */
-                'acl' => 'public-read',
-
-                /*
-                |--------------------------------------------------------------------------
-                | Use CloudFront as the CDN
-                |--------------------------------------------------------------------------
-                |
-                | Amazon S3 can be linked to CloudFront through distributions. This allows
-                | the files in your S3 buckets to be served from a number of global
-                | locations to achieve low latency and faster page load times.
-                */
-                'cloudfront' => [
-                    'use'       => false,
-                    'cdn_url'   => '',
-                ],
+                'acl' => 'public-read'
 
             ],
 

--- a/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
@@ -68,7 +68,11 @@ class AwsS3ProviderTest extends TestCase {
                         'buckets' => [
                             'ZZZZZZZ' => '*',
                         ],
-                        'acl' => 'public-read'
+                        'acl' => 'public-read',
+                        'cloudfront' => [
+                            'use'       => false,
+                            'cdn_url'   => null,
+                        ],
                     ],
                 ],
             ],
@@ -95,7 +99,11 @@ class AwsS3ProviderTest extends TestCase {
                         'buckets' => [
                             'ZZZZZZZ' => '*',
                         ],
-                        'acl' => 'public-read'
+                        'acl' => 'public-read',
+                        'cloudfront' => [
+                            'use'       => false,
+                            'cdn_url'   => null,
+                        ],
                     ],
                 ],
             ],
@@ -124,7 +132,11 @@ class AwsS3ProviderTest extends TestCase {
                         'buckets' => [
                             'ZZZZZZZ' => '*',
                         ],
-                        'acl' => 'public-read'
+                        'acl' => 'public-read',
+                        'cloudfront' => [
+                            'use'       => false,
+                            'cdn_url'   => null,
+                        ],
                     ],
                 ],
             ],
@@ -153,7 +165,11 @@ class AwsS3ProviderTest extends TestCase {
                         'buckets' => [
                             '' => '*',
                         ],
-                        'acl' => 'public-read'
+                        'acl' => 'public-read',
+                        'cloudfront' => [
+                            'use'       => false,
+                            'cdn_url'   => null,
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
A lot of people use their S3 buckets to host their assets and then use CloudFront as a means of delivering that content. The advantage to this is CloudFront offers a true CDN from multiple locations across the globe, reducing page load times substantially.

There is currently no scope within this version, to push assets up to S3 and then have it served to the user via a CloudFront URL. This pull request should address that.