### PR TITLE
use the mockery version 0.9.3 as version 0.9.4 requires

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.*",
-        "mockery/mockery": "0.9.*"
+        "mockery/mockery": "0.9.3"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
hamcrest/hamcrest-php 1.2.2 and this is causing the following error
while testing:

Fatal error: Cannot redeclare any() (previously declared in /Users/mz/Codes/Projects/PHP-Packages/cdn/vendor/hamcrest/hamcrest-php/hamcrest/Hamcrest.php:395) in /Users/mz/Codes/Projects/PHP-Packages/cdn/vendor/ph
punit/phpunit/src/Framework/Assert/Functions.php on line 59