### PR TITLE
Added 'cdn:empty' to empty an S3 bucket

### DIFF
--- a/src/Vinelab/Cdn/Cdn.php
+++ b/src/Vinelab/Cdn/Cdn.php
@@ -85,4 +85,18 @@ class Cdn implements CdnInterface
         return $provider->upload($this->asset_holder->getAssets());
     }
 
+    /**
+     * Will be called from the Vinelab\Cdn\EmptyCommand class on Fire()
+     */
+    public function emptyBucket()
+    {
+        // return the configurations from the config file
+        $configurations = $this->helper->getConfigurations();
+
+        // return an instance of the corresponding Provider concrete according to the configuration
+        $provider = $this->provider_factory->create($configurations);
+
+        return $provider->emptyBucket();
+    }
+
 }

--- a/src/Vinelab/Cdn/CdnServiceProvider.php
+++ b/src/Vinelab/Cdn/CdnServiceProvider.php
@@ -101,6 +101,12 @@ class CdnServiceProvider extends ServiceProvider
 
         $this->commands('cdn.push');
 
+        $this->app['cdn.empty'] = $this->app->share(function () {
+            return $this->app->make('Vinelab\Cdn\Commands\EmptyCommand');
+        });
+
+        $this->commands('cdn.empty');
+
         // facade bindings:
         //-----------------
 

--- a/src/Vinelab/Cdn/Commands/EmptyCommand.php
+++ b/src/Vinelab/Cdn/Commands/EmptyCommand.php
@@ -1,0 +1,82 @@
+<?php
+namespace Vinelab\Cdn\Commands;
+
+use Illuminate\Console\Command;
+use Vinelab\Cdn\Contracts\CdnInterface;
+
+/**
+ * Class PushCommand
+ *
+ * @category Command
+ * @package  Vinelab\Cdn\Commands
+ * @author   Mahmoud Zalt <mahmoud@vinelab.com>
+ */
+class EmptyCommand extends Command
+{
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'cdn:empty';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Empty all assets from CDN';
+
+    /**
+     * an instance of the main Cdn class
+     *
+     * @var Vinelab\Cdn\Cdn
+     */
+    protected $cdn;
+
+    /**
+     * @param CdnInterface $cdn
+     */
+    public function __construct(CdnInterface $cdn)
+    {
+        $this->cdn = $cdn;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function fire()
+    {
+        $this->cdn->emptyBucket();
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return array(
+//			array('cdn', InputArgument::OPTIONAL, 'cdn option.'),
+        );
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return array(
+//			array('example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null),
+        );
+    }
+
+}

--- a/src/Vinelab/Cdn/Contracts/CdnInterface.php
+++ b/src/Vinelab/Cdn/Contracts/CdnInterface.php
@@ -11,4 +11,7 @@ interface CdnInterface
 
     public function push();
 
+    public function emptyBucket();
+
+
 } 

--- a/src/Vinelab/Cdn/Providers/Contracts/ProviderInterface.php
+++ b/src/Vinelab/Cdn/Providers/Contracts/ProviderInterface.php
@@ -13,6 +13,8 @@ interface ProviderInterface
 
     public function upload($assets);
 
+    public function emptyBucket();
+
     public function urlGenerator($path);
 
     public function getUrl();


### PR DESCRIPTION
I noticed that my S3 bucket was continually getting 'crudded' up with lots of CSS and JS versioned files. The ```cdn:empty``` command clears the bucket ready for ```cdn:push``` to be run.

This is fully tested but I've not written any Mockery tests...I'm rubbish at them so will try and write one soon.