### PR TITLE
Update composer.json to work with Laravel 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-- 5.4
 - 5.5
 - 5.6
 - 7.0
@@ -10,8 +9,6 @@ php:
 matrix:
   allow_failures:
     - php: 7.0
-  include:
-    - php: 5.4
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "illuminate/support": "5.0.*",
-        "illuminate/config": "5.0.*",
-        "symfony/finder": "2.6.*",
-        "symfony/console": "2.6.*",
-        "guzzlehttp/guzzle": "5.3.*",
+        "php": ">=5.5.0",
+        "illuminate/support": "~5.0",
+        "illuminate/config": "~5.0",
+        "symfony/finder": "2.7.*",
+        "symfony/console": "2.7.*",
+        "guzzlehttp/guzzle": "~5.3",
         "aws/aws-sdk-php": "2.8.*"
     },
     "require-dev": {


### PR DESCRIPTION
Hoping this will now work for Laravel 5.1.

I should be noted that v5.1. requires AWS ~3.0 if people use AQS for queuing or SES.