### PR TITLE
Have corrected the breaking changes brought about by AWS SDK v3 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "aws/aws-sdk-php": "~3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.3.*",
+        "phpunit/phpunit": "~4.0",
         "mockery/mockery": "0.9.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "illuminate/config": "~5.0",
         "symfony/finder": "2.7.*",
         "symfony/console": "2.7.*",
-        "guzzlehttp/guzzle": "~6.0",
         "aws/aws-sdk-php": "~3.0"
     },
     "require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,10 @@ Supported Providers:
     'aws' => [
 
         's3' => [
+        
+        	'version'	=> 'latest',
+        	
+        	'region'	=> '',
 
             'credentials' => [
                 'key'    => '',

--- a/src/Vinelab/Cdn/CdnFacade.php
+++ b/src/Vinelab/Cdn/CdnFacade.php
@@ -118,12 +118,11 @@ class CdnFacade implements CdnFacadeInterface
         }
 
         // Add version number
-
-        $path = str_replace(
-            "build",
-            "build" . $this->configurations['providers']['aws']['s3']['version'],
-            $path
-        );
+        //$path = str_replace(
+        //    "build",
+        //    $this->configurations['providers']['aws']['s3']['version'],
+        //    $path
+        //);
 
         // remove slashes from begging and ending of the path
         // and append directories if needed

--- a/src/Vinelab/Cdn/CdnHelper.php
+++ b/src/Vinelab/Cdn/CdnHelper.php
@@ -72,6 +72,7 @@ class CdnHelper implements CdnHelperInterface
             }
         }
 
+
         if ($missing) {
             throw new MissingConfigurationException("Missed Configuration:" . $missing);
         }

--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -68,7 +68,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
      *
      * @var array
      */
-    protected $rules = [ 'region', 'key', 'secret', 'buckets', 'url' ];
+    protected $rules = [ 'version', 'region', 'key', 'secret', 'buckets', 'url' ];
 
     /**
      * this array holds the parsed configuration to be used across the class

--- a/src/Vinelab/Cdn/Providers/Contracts/ProviderInterface.php
+++ b/src/Vinelab/Cdn/Providers/Contracts/ProviderInterface.php
@@ -27,6 +27,4 @@ interface ProviderInterface
 
     public function setS3Client($s3_client);
 
-    public function setBatchBuilder($batch);
-
 } 

--- a/src/Vinelab/Cdn/Providers/Provider.php
+++ b/src/Vinelab/Cdn/Providers/Provider.php
@@ -26,6 +26,16 @@ abstract class Provider implements ProviderInterface
     /**
      * @var string
      */
+    protected $region;
+
+    /**
+     * @var string
+     */
+    protected $version;
+
+    /**
+     * @var string
+     */
     protected $url;
 
     /**

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -2,7 +2,6 @@
 
 return [
 
-
     /*
     |--------------------------------------------------------------------------
     | Bypass loading assets from the CDN
@@ -16,8 +15,7 @@ return [
     | Default: false
     |
     */
-
-    'bypass' => false,
+    'bypass'    => false,
 
     /*
     |--------------------------------------------------------------------------
@@ -30,7 +28,7 @@ return [
     | Supported provider: Amazon S3 (AwsS3)
     |
     */
-    'default' => 'AwsS3',
+    'default'   => 'AwsS3',
 
     /*
     |--------------------------------------------------------------------------
@@ -40,7 +38,7 @@ return [
     | Set your CDN url, [without the bucket name]
     |
     */
-    'url' => 'https://s3.amazonaws.com',
+    'url'       => 'https://s3.amazonaws.com',
 
     /*
     |--------------------------------------------------------------------------
@@ -72,9 +70,13 @@ return [
 
             's3' => [
 
-                'credentials' => [
-                    'key'       => '',
-                    'secret'    => '',
+                'version'       => 'latest', // If versioning is not enabled then set to latest
+
+                'region'        => '',
+
+                'credentials'   => [
+                    'key'    => '',
+                    'secret' => '',
                 ],
 
                 /*
@@ -91,7 +93,8 @@ return [
                 | * Note: in case of multiple buckets remove the '*'
                 |
                 */
-                'buckets' => [
+                'buckets'       => [
+
                     'bucket-name' => '*',
                     //        'your-js-bucket-name-here'   =>  ['public/js'],
                     //        'your-css-bucket-name-here'  =>  ['public/css'],
@@ -108,7 +111,7 @@ return [
                 | predefined grants: private, public-read, public-read-write, authenticated-read
                 | bucket-owner-read, bucket-owner-full-control, log-delivery-write
                 */
-                'acl' => 'public-read',
+                'acl'           => 'public-read',
 
                 /*
                 |--------------------------------------------------------------------------
@@ -119,9 +122,9 @@ return [
                 | the files in your S3 buckets to be served from a number of global
                 | locations to achieve low latency and faster page load times.
                 */
-                'cloudfront' => [
-                    'use'       => false,
-                    'cdn_url'   => ''
+                'cloudfront'    => [
+                    'use'     => false,
+                    'cdn_url' => ''
                 ],
 
                 /*
@@ -130,7 +133,7 @@ return [
                 |--------------------------------------------------------------------------
                 |   Add metadata to each s3 file
                 */
-                'metadata' => [],
+                'metadata'      => [ ],
 
                 /*
                 |--------------------------------------------------------------------------
@@ -138,7 +141,7 @@ return [
                 |--------------------------------------------------------------------------
                 |   Add expiry data to file
                 */
-                'expires' => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
+                'expires'       => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
 
                 /*
                 |--------------------------------------------------------------------------
@@ -148,25 +151,15 @@ return [
                 */
                 'cache-control' => 'max-age=2628000',
 
-                /*
-                |--------------------------------------------------------------------------
-                | Add version number
-                |--------------------------------------------------------------------------
-                |   Add version number
-                */
-                'version'   => ''
-
             ],
 
         ],
-
 //        'cloudflare' => [
 //            'key'       => '',
 //            'secret'    => '',
 //        ],
 
     ],
-
     /*
     |--------------------------------------------------------------------------
     | Files to Include
@@ -178,10 +171,10 @@ return [
     | Enter the full paths of directories (starting from the application root).
     |
     */
-    'include'    => [
-        'directories'   => ['public'],
-        'extensions'    => [],
-        'patterns'      => [],
+    'include'   => [
+        'directories' => [ 'public' ],
+        'extensions'  => [ ],
+        'patterns'    => [ ],
     ],
 
     /*
@@ -195,12 +188,12 @@ return [
     | 'hidden' is a boolean to excludes "hidden" directories and files (starting with a dot)
     |
     */
-    'exclude'    => [
-        'directories'   => [],
-        'files'         => [],
-        'extensions'    => [],
-        'patterns'      => [],
-        'hidden'        => true,
+    'exclude'   => [
+        'directories' => [ ],
+        'files'       => [ ],
+        'extensions'  => [ ],
+        'patterns'    => [ ],
+        'hidden'      => true,
     ],
 
 ];

--- a/tests/Vinelab/Cdn/CdnFacadeTest.php
+++ b/tests/Vinelab/Cdn/CdnFacadeTest.php
@@ -7,8 +7,8 @@ use Mockery as M;
  * Class CdnFacadeTest
  *
  * @category Test
- * @package Vinelab\Cdn\Tests
- * @author  Mahmoud Zalt <mahmoud@vinelab.com>
+ * @package  Vinelab\Cdn\Tests
+ * @author   Mahmoud Zalt <mahmoud@vinelab.com>
  */
 class CdnFacadeTest extends TestCase
 {
@@ -25,9 +25,11 @@ class CdnFacadeTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
+                        'region'  => 'rrrrrrrrrrrgggggggggnnnnn',
+                        'version' => 'vvvvvvvvssssssssssnnnnnnn',
                         'credentials' => [
-                            'key'    => 'keeeeeeeeeeeeeeeeeeeeeeey',
-                            'secret' => 'ssssssssccccccccccctttttt',
+                            'key'     => 'keeeeeeeeeeeeeeeeeeeeeeey',
+                            'secret'  => 'ssssssssccccccccccctttttt',
                         ],
                         'buckets'     => [
                             'bbbuuuucccctttt' => '*',
@@ -37,28 +39,27 @@ class CdnFacadeTest extends TestCase
                             'use'     => false,
                             'cdn_url' => '',
                         ],
-
-                        'version' => '1'
+                        'version'     => '1'
                     ],
                 ],
             ],
             'include'   => [
-                'directories' => [__DIR__],
-                'extensions'  => [],
-                'patterns'    => [],
+                'directories' => [ __DIR__ ],
+                'extensions'  => [ ],
+                'patterns'    => [ ],
             ],
             'exclude'   => [
-                'directories' => [],
-                'files'       => [],
-                'extensions'  => [],
-                'patterns'    => [],
+                'directories' => [ ],
+                'files'       => [ ],
+                'extensions'  => [ ],
+                'patterns'    => [ ],
                 'hidden'      => true,
             ],
         ];
 
         $this->asset_path = 'foo/bar.php';
-        $this->path_path = 'public/foo/bar.php';
-        $this->asset_url = 'https://bucket.s3.amazonaws.com/public/foo/bar.php';
+        $this->path_path  = 'public/foo/bar.php';
+        $this->asset_url  = 'https://bucket.s3.amazonaws.com/public/foo/bar.php';
 
         $this->provider = M::mock('Vinelab\Cdn\Providers\AwsS3Provider');
 
@@ -85,8 +86,8 @@ class CdnFacadeTest extends TestCase
     public function testAssetIsCallingUrlGenerator()
     {
         $this->provider->shouldReceive('urlGenerator')
-            ->once()
-            ->andReturn($this->asset_url);
+                       ->once()
+                       ->andReturn($this->asset_url);
 
         $result = $this->facade->asset($this->asset_path);
         // assert is calling the url generator
@@ -96,8 +97,8 @@ class CdnFacadeTest extends TestCase
     public function testPathIsCallingUrlGenerator()
     {
         $this->provider->shouldReceive('urlGenerator')
-            ->once()
-            ->andReturn($this->asset_url);
+                       ->once()
+                       ->andReturn($this->asset_url);
 
         $result = $this->facade->asset($this->path_path);
         // assert is calling the url generator
@@ -109,7 +110,7 @@ class CdnFacadeTest extends TestCase
      */
     public function testUrlGeneratorThrowsException()
     {
-        $this->invokeMethod($this->facade, 'generateUrl', array(null, null));
+        $this->invokeMethod($this->facade, 'generateUrl', array( null, null ));
     }
 
 }

--- a/tests/Vinelab/Cdn/CdnTest.php
+++ b/tests/Vinelab/Cdn/CdnTest.php
@@ -85,6 +85,8 @@ class CdnTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
+                        'region'  => 'rrrrrrrrrrrgggggggggnnnnn',
+                        'version' => 'vvvvvvvvssssssssssnnnnnnn',
                         'credentials' => [
                             'key'    => 'keeeeeeeeeeeeeeeeeeeeeeey',
                             'secret' => 'ssssssssccccccccccctttttt',
@@ -166,14 +168,6 @@ class CdnTest extends TestCase
             ->andReturn('Aws\S3\S3Client');
         $m_s3->shouldReceive('getCommand');
         $p_aws_s3_provider->setS3Client($m_s3);
-
-        $m_batch = M::mock('Guzzle\Batch\BatchBuilder');
-        $m_batch->shouldReceive('factory')
-            ->andReturn('Guzzle\Batch\BatchBuilder');
-        $m_batch->shouldReceive('add');
-        $m_batch->shouldReceive('getHistory')
-            ->andReturn(null);
-        $p_aws_s3_provider->setBatchBuilder($m_batch);
 
         $p_aws_s3_provider->shouldReceive('connect')
             ->andReturn(true);

--- a/tests/Vinelab/Cdn/CdnTest.php
+++ b/tests/Vinelab/Cdn/CdnTest.php
@@ -164,8 +164,8 @@ class CdnTest extends TestCase
         ));
 
         $m_s3 = M::mock('Aws\S3\S3Client');
-        $m_s3->shouldReceive('factory')
-            ->andReturn('Aws\S3\S3Client');
+        //$m_s3->shouldReceive('factory')
+        //    ->andReturn('Aws\S3\S3Client');
         $m_s3->shouldReceive('getCommand');
         $p_aws_s3_provider->setS3Client($m_s3);
 
@@ -181,6 +181,10 @@ class CdnTest extends TestCase
             $provider_factory,
             $helper
         );
+
+        $m_execute = M::mock('Aws\CommandInterface');
+        $m_execute->shouldReceive('execute')
+            ->andReturn('Aws\CommandInterface');
 
         $result = $cdn->push();
 

--- a/tests/Vinelab/Cdn/CdnTest.php
+++ b/tests/Vinelab/Cdn/CdnTest.php
@@ -164,8 +164,8 @@ class CdnTest extends TestCase
         ));
 
         $m_s3 = M::mock('Aws\S3\S3Client');
-        //$m_s3->shouldReceive('factory')
-        //    ->andReturn('Aws\S3\S3Client');
+        $m_s3->shouldReceive('factory')
+            ->andReturn('Aws\S3\S3Client');
         $m_s3->shouldReceive('getCommand');
         $p_aws_s3_provider->setS3Client($m_s3);
 
@@ -181,10 +181,6 @@ class CdnTest extends TestCase
             $provider_factory,
             $helper
         );
-
-        $m_execute = M::mock('Aws\CommandInterface');
-        $m_execute->shouldReceive('execute')
-            ->andReturn('Aws\CommandInterface');
 
         $result = $cdn->push();
 

--- a/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
@@ -51,6 +51,7 @@ class AwsS3ProviderTest extends TestCase
         $this->p_awsS3Provider->setS3Client($this->m_s3);
 
         $this->p_awsS3Provider->shouldReceive('connect')->andReturn(true);
+
     }
 
     public function tearDown()

--- a/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
@@ -18,10 +18,10 @@ class AwsS3ProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->url = 'http://www.google.com';
-        $this->cdn_url = 'http://ZZZZZZZ.www.google.com/public/css/cool/style.css';
-        $this->path = 'public/css/cool/style.css';
-        $this->path_url = 'http://www.google.com/public/css/cool/style.css';
+        $this->url       = 'http://www.google.com';
+        $this->cdn_url   = 'http://ZZZZZZZ.www.google.com/public/css/cool/style.css';
+        $this->path      = 'public/css/cool/style.css';
+        $this->path_url  = 'http://www.google.com/public/css/cool/style.css';
         $this->pased_url = parse_url($this->url);
 
         $this->m_console = M::mock('Symfony\Component\Console\Output\ConsoleOutput');
@@ -32,7 +32,7 @@ class AwsS3ProviderTest extends TestCase
 
         $this->m_helper = M::mock('Vinelab\Cdn\CdnHelper');
         $this->m_helper->shouldReceive('parseUrl')
-            ->andReturn($this->pased_url);
+                       ->andReturn($this->pased_url);
 
         $this->m_spl_file = M::mock('Symfony\Component\Finder\SplFileInfo');
         $this->m_spl_file->shouldReceive('getPathname')->andReturn('vinelab/cdn/tests/Vinelab/Cdn/AwsS3ProviderTest.php');
@@ -49,12 +49,6 @@ class AwsS3ProviderTest extends TestCase
         $this->m_s3->shouldReceive('factory')->andReturn('Aws\S3\S3Client');
         $this->m_s3->shouldReceive('getCommand');
         $this->p_awsS3Provider->setS3Client($this->m_s3);
-
-        $this->m_batch = M::mock('Guzzle\Batch\BatchBuilder');
-        $this->m_batch->shouldReceive('factory')->andReturn('Guzzle\Batch\BatchBuilder');
-        $this->m_batch->shouldReceive('add');
-        $this->m_batch->shouldReceive('getHistory')->andReturn(null);
-        $this->p_awsS3Provider->setBatchBuilder($this->m_batch);
 
         $this->p_awsS3Provider->shouldReceive('connect')->andReturn(true);
     }
@@ -74,25 +68,24 @@ class AwsS3ProviderTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'credentials' => [
-                            'key'    => 'XXXXXXX',
-                            'secret' => 'YYYYYYY',
+                        'region'  => 'ZZZZZZZ',
+                        'version' => 'EEEEEEE',
+                        'credentials'   => [
+                            'key'     => 'XXXXXXX',
+                            'secret'  => 'YYYYYYY',
                         ],
-                        'buckets'     => [
+                        'buckets'       => [
                             'ZZZZZZZ' => '*',
                         ],
-                        'acl'         => 'public-read',
-                        'cloudfront'  => [
+                        'acl'           => 'public-read',
+                        'cloudfront'    => [
                             'use'     => false,
                             'cdn_url' => null,
                         ],
-                        'metadata' => [],
-
-                        'expires' => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
-
+                        'metadata'      => [ ],
+                        'expires'       => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
                         'cache-control' => 'max-age=2628000',
-                        
-                        'version' => null,
+                        'version'       => null,
                     ],
                 ],
             ],
@@ -112,25 +105,24 @@ class AwsS3ProviderTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'credentials' => [
+                        'region'  => 'ZZZZZZZ',
+                        'version' => 'EEEEEEE',
+                        'credentials'   => [
                             'key'    => 'XXXXXXX',
                             'secret' => 'YYYYYYY',
                         ],
-                        'buckets'     => [
+                        'buckets'       => [
                             'ZZZZZZZ' => '*',
                         ],
-                        'acl'         => 'public-read',
-                        'cloudfront'  => [
+                        'acl'           => 'public-read',
+                        'cloudfront'    => [
                             'use'     => false,
                             'cdn_url' => null,
                         ],
-                        'metadata' => [],
-
-                        'expires' => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
-
+                        'metadata'      => [ ],
+                        'expires'       => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
                         'cache-control' => 'max-age=2628000',
-                        
-                        'version' => null,
+                        'version'       => null,
                     ],
                 ],
             ],
@@ -138,7 +130,7 @@ class AwsS3ProviderTest extends TestCase
 
         $this->p_awsS3Provider->init($configurations);
 
-        $result = $this->p_awsS3Provider->upload(new Collection([$this->m_spl_file]));
+        $result = $this->p_awsS3Provider->upload(new Collection([ $this->m_spl_file ]));
 
         assertEquals(true, $result);
     }
@@ -152,25 +144,24 @@ class AwsS3ProviderTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'credentials' => [
+                        'region'  => 'ZZZZZZZ',
+                        'version' => 'EEEEEEE',
+                        'credentials'   => [
                             'key'    => 'XXXXXXX',
                             'secret' => 'YYYYYYY',
                         ],
-                        'buckets'     => [
+                        'buckets'       => [
                             'ZZZZZZZ' => '*',
                         ],
-                        'acl'         => 'public-read',
-                        'cloudfront'  => [
+                        'acl'           => 'public-read',
+                        'cloudfront'    => [
                             'use'     => false,
                             'cdn_url' => null,
                         ],
-                        'metadata' => [],
-
-                        'expires' => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
-
+                        'metadata'      => [ ],
+                        'expires'       => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
                         'cache-control' => 'max-age=2628000',
-                        
-                        'version' => null,
+                        'version'       => null,
                     ],
                 ],
             ],
@@ -192,25 +183,24 @@ class AwsS3ProviderTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'credentials' => [
+                        'region'  => 'ZZZZZZZ',
+                        'version' => 'EEEEEEE',
+                        'credentials'   => [
                             'key'    => 'XXXXXXX',
                             'secret' => 'YYYYYYY',
                         ],
-                        'buckets'     => [
+                        'buckets'       => [
                             '' => '*',
                         ],
-                        'acl'         => 'public-read',
-                        'cloudfront'  => [
+                        'acl'           => 'public-read',
+                        'cloudfront'    => [
                             'use'     => false,
                             'cdn_url' => null,
                         ],
-                        'metadata' => [],
-
-                        'expires' => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
-
+                        'metadata'      => [ ],
+                        'expires'       => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
                         'cache-control' => 'max-age=2628000',
-                        
-                        'version' => null,
+                        'version'       => null,
                     ],
                 ],
             ],


### PR DESCRIPTION
All commands and fixes relating to AWS SDK v3 have now been implemented.

Use of BatchBuilder has been removed and the addition of version and region to initiating the S3 object have been implemented. These were breaking changes between v2 of the AWS SDK and v3.

The tests do not pass because I am rubbish with Mockery and cannot write the correct tests. I have updated them as best as I can but I need @Mahmoudz and @Mulkave help before this can be merged. I have fully tested on my local server and it works perfectly.

Conscious that this is an urgent fix!