### PR TITLE
Fix tests to support AWS SDK v3

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# CDN Assets Manager
+# Laravel CDN Assets Manager
 
 [![Total Downloads](https://poser.pugx.org/vinelab/cdn/downloads)](https://packagist.org/packages/vinelab/cdn) 
 [![Latest Stable Version](https://poser.pugx.org/vinelab/cdn/v/stable)](https://packagist.org/packages/vinelab/cdn) 
@@ -10,191 +10,182 @@
 
 ##### Content Delivery Network Package for Laravel
 
-Upload static assets of your choice to a CDN and have the file paths replaced with full URLs.
-
-
+The package provides the devloper the ability to upload his assets (or any public file) to a CDN with a single artisan command. 
+And then it allows him to switch between the local and the online version  of the files, for develpoment and production purposes.
 
 
 ## Highlights
 
+
+- Amazon Web Services - S3
 - Supports Laravel 5.1
+- Artisan command to upload content to CDN
+- Simple Facade to access CDN assets
 
 
+## Installation
 
+#### Via Composer
 
+A. Require `vinelab/cdn` in your project:
 
-## Install
+```bash 
+composer require vinelab/cdn:*
+```
 
-### Via Composer
+*Since this is a Laravel package we need to register the service provider:*
 
-- Add the package to your `composer.json` and run `composer update`
+Add the service provider to `app/config/app.php`:
 
-    ```json
-    {
-        "require": {
-            "vinelab/cdn": "*"
-        }
-    }
-    ```
-
-- Add the service provider to `app/config/app.php`:
-
-    ```php
-    'providers' => array(
-        '...',
-        Vinelab\Cdn\CdnServiceProvider::class,
-        '...'
-    ),
-    ```
-
-The service provider will register all the required classes for this package and will also alias
-the `Cdn` class to `CdnFacadeProvider` so you can simply use the `Cdn` facade anywhere in your app.
+```php
+'providers' => array(
+	 //...
+     Vinelab\Cdn\CdnServiceProvider::class,
+),
+```
 
 ## Configuration
 
-Publish the package config file:
+First you need to publish the package config file:
 
 ```bash
 php artisan vendor:publish vinelab/cdn
 ```
 
-Find it at `config/cdn.php`
+You can find it at `config/cdn.php`
 
-### Providers
 
-Supported Providers:
-
-- Amazon Web Services - S3 (Default)
-
-#### Default Provider
+##### Default Provider
 ```php
 'default' => 'AwsS3',
 ```
 
-#### CDN Provider Setup
+##### CDN Provider Configuration
 
 ```php
-    'aws' => [
+'aws' => [
 
-        's3' => [
-        
-        	'version'	=> 'latest',
-        	
-        	'region'	=> '',
+    's3' => [
+    
+        'version'	=> 'latest',
+        'region'	=> '',
 
-            'credentials' => [
-                'key'    => '',
-                'secret'    => '',
-            ],
-
-            'buckets' => [
-                'my-backup-bucket' => '*',
-            ]
+        'buckets' => [
+            'my-backup-bucket' => '*',
         ]
-    ],
+    ]
+],
 ```
 
-##### Multiple Buckets
+###### Multiple Buckets
 
 ```php
 'buckets' => [
 
     'my-default-bucket' => '*',
-    'js-bucket' => ['public/js'],
-    'css-bucket' => ['public/css'],
-    '...'
+    
+    // 'js-bucket' => ['public/js'],
+    // 'css-bucket' => ['public/css'],
+    // ...
 ]
 
 ```
 
-### Files & Directories
+#### Files & Directories
 
-#### Include
+###### Include:
 
 Specify directories, extensions, files and patterns to be uploaded.
 
 ```php
-    'include'    => [
-        'directories'   => ['public/dist'],
-        'extensions'    => ['.js', '.css', '.yxz'],
-        'patterns'      => ['**/*.coffee'],
-    ],
+'include'    => [
+    'directories'   => ['public/dist'],
+    'extensions'    => ['.js', '.css', '.yxz'],
+    'patterns'      => ['**/*.coffee'],
+],
 ```
 
-#### Exclude
+###### Exclude:
 
 Specify what to be ignored.
 
 ```php
-    'exclude'    => [
-        'directories'   => ['public/uploads'],
-        'files'         => [''],
-        'extensions'    => ['.TODO', '.txt'],
-        'patterns'      => ['src/*', '.idea/*'],
-        'hidden'        => true, // ignore hidden files
-    ],
+'exclude'    => [
+    'directories'   => ['public/uploads'],
+    'files'         => [''],
+    'extensions'    => ['.TODO', '.txt'],
+    'patterns'      => ['src/*', '.idea/*'],
+    'hidden'        => true, // ignore hidden files
+],
 ```
 
-#### URL
+##### URL
 
 Set the CDN URL:
 
 ```php
-    'url' => 'https://s3.amazonaws.com',
+'url' => 'https://s3.amazonaws.com',
 ```
 
-#### Threshold
-Determines how many files to be uploaded concurrently.
+##### Bypass
 
-> Will clear the buffer when the `threshold` has been reached, be careful when setting this to a high value
-not to exceed what you have allowed in your PHP configuration.
+To load your LOCAL assets for testing or during development, set the `bypass` option to `true`:
 
 ```php
-    'threshold' => 10,
+'bypass' => true,
 ```
 
-#### Bypass
-
-To load your local assets (not the CDN assets) for testing or during development, set the `bypass` option to `true`:
+##### Cloudfront Support
 
 ```php
-    'bypass' => true,
+'cloudfront'    => [
+    'use' => false,
+    'cdn_url' => ''
+],
 ```
+
+
+##### Other Configurations
+You can always refer to the AWS S3 Docuemntation for more details: [aws-sdk-php](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/)
+
+```php
+'acl'           => 'public-read',
+'metadata'      => [ ],
+'expires'       => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
+'cache-control' => 'max-age=2628000',
+```
+
 ## Usage
 
-### Push
+#### Push
 
 Upload your assets with
-```dos
+```bash
 php artisan cdn:push
 ```
-### Empty
+#### Empty
 
 Delete all of your assets remotely with
-```dos
+```bash
 php artisan cdn:empty
 ```
-### Load Assets
 
-Now you can use the facade `Cdn` to call the `Cdn::asset()` function.
-Note: the `asset` works the same as the Laravel `asset` it start looking for assets in the `public/` directory:
+#### Load Assets
+
+Use the facade `Cdn` to call the `Cdn::asset()` function.
+
+*Note: the `asset` works the same as the Laravel `asset` it start looking for assets in the `public/` directory:*
 
 ```blade
-    {{Cdn::asset('assets/js/main.js')}}
-    // https://js-bucket.s3.amazonaws.com/public/assets/js/main.js
+{{Cdn::asset('assets/js/main.js')}}        // example result: https://js-bucket.s3.amazonaws.com/public/assets/js/main.js
 
-    {{Cdn::asset('assets/css/main.css')}}
-    // https://css-bucket.s3.amazonaws.com/public/assets/css/main.css
+{{Cdn::asset('assets/css/style.css')}}        // example result: https://css-bucket.s3.amazonaws.com/public/assets/css/style.css
 ```
 
-If you want to use a file from outside the `public/` directory anywhere in `app/` you can use the `Cdn::path()` function to do that:
+To use a file from outside the `public/` directory, anywhere in `app/` use the `Cdn::path()` function:
 
 ```blade
-    {{Cdn::path('public/assets/js/main.js')}}
-    // https://js-bucket.s3.amazonaws.com/public/assets/js/main.js
-
-    {{Cdn::path('private/something/file.txt')}}
-    // https://css-bucket.s3.amazonaws.com/private/something/file.txt
+{{Cdn::path('private/something/file.txt')}}        // example result: https://css-bucket.s3.amazonaws.com/private/something/file.txt
 ```
 
 
@@ -206,6 +197,19 @@ If you want to use a file from outside the `public/` directory anywhere in `app/
 
 
 
+
+
+## Test
+
+To run the tests, run the following command from the project folder.
+
+```bash
+$ ./vendor/bin/phpunit
+```
+
+## Support
+
+[On Github](https://github.com/Vinelab/cdn/issues)
 
 
 ## Contributing

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,8 @@
 
 ##### Content Delivery Network Package for Laravel
 
-The package provides the devloper the ability to upload his assets (or any public file) to a CDN with a single artisan command. 
-And then it allows him to switch between the local and the online version  of the files, for develpoment and production purposes.
-
+The package provides the developer the ability to upload his assets (or any public file) to a CDN with a single artisan command.
+And then it allows him to switch between the local and the online version of the files, for development and production purposes.
 
 ## Highlights
 
@@ -46,7 +45,16 @@ Add the service provider to `app/config/app.php`:
 
 ## Configuration
 
-First you need to publish the package config file:
+Set AWS Credentials to the `.env` file.
+
+*Note: you should have an `.env` file at the project root directory of your project, to hold your sensitive information.*
+
+```bash
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+```
+
+Publish the package config file:
 
 ```bash
 php artisan vendor:publish vinelab/cdn

--- a/readme.md
+++ b/readme.md
@@ -45,9 +45,9 @@ Add the service provider to `app/config/app.php`:
 
 ## Configuration
 
-Set AWS Credentials to the `.env` file.
+Set the Credentials in the `.env` file.
 
-*Note: you should have an `.env` file at the project root directory of your project, to hold your sensitive information.*
+*Note: you must have an `.env` file at the project root, to hold your sensitive information.*
 
 ```bash
 AWS_ACCESS_KEY_ID=
@@ -162,7 +162,7 @@ To load your LOCAL assets for testing or during development, set the `bypass` op
 'cache-control' => 'max-age=2628000',
 ```
 
-You can always refer to the AWS S3 Docuemntation for more details: [aws-sdk-php](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/)
+You can always refer to the AWS S3 Documentation for more details: [aws-sdk-php](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/)
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -8,16 +8,16 @@
 [![License](https://poser.pugx.org/vinelab/cdn/license)](https://packagist.org/packages/vinelab/cdn)
 
 
-Content Delivery Network Package for Laravel
+##### Content Delivery Network Package for Laravel
 
 Upload static assets of your choice to a CDN and have the file paths replaced with full URLs.
-----------
 
 
 
 
+## Highlights
 
-
+- Supports Laravel 5.1
 
 
 
@@ -42,7 +42,7 @@ Upload static assets of your choice to a CDN and have the file paths replaced wi
     ```php
     'providers' => array(
         '...',
-        'Vinelab\Cdn\CdnServiceProvider',
+        Vinelab\Cdn\CdnServiceProvider::class,
         '...'
     ),
     ```
@@ -53,12 +53,12 @@ the `Cdn` class to `CdnFacadeProvider` so you can simply use the `Cdn` facade an
 ## Configuration
 
 Publish the package config file:
-```dos
+
+```bash
 php artisan vendor:publish vinelab/cdn
 ```
-and check it out at `app/config/packages/vinelab/cdn/cdn.php`
 
-In case you would like to have environment-based configuration `app/config/packages/vinelab/cdn/[ENV]/cdn.php`
+Find it at `config/cdn.php`
 
 ### Providers
 

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ And then it allows him to switch between the local and the online version  of th
 
 #### Via Composer
 
-A. Require `vinelab/cdn` in your project:
+Require `vinelab/cdn` in your project:
 
 ```bash 
 composer require vinelab/cdn:*
@@ -146,7 +146,6 @@ To load your LOCAL assets for testing or during development, set the `bypass` op
 
 
 ##### Other Configurations
-You can always refer to the AWS S3 Docuemntation for more details: [aws-sdk-php](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/)
 
 ```php
 'acl'           => 'public-read',
@@ -155,17 +154,19 @@ You can always refer to the AWS S3 Docuemntation for more details: [aws-sdk-php]
 'cache-control' => 'max-age=2628000',
 ```
 
+You can always refer to the AWS S3 Docuemntation for more details: [aws-sdk-php](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/)
+
 ## Usage
 
 #### Push
 
-Upload your assets with
+Upload assets
 ```bash
 php artisan cdn:push
 ```
 #### Empty
 
-Delete all of your assets remotely with
+Delete all of your assets remotely
 ```bash
 php artisan cdn:empty
 ```

--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -221,8 +221,9 @@ class AwsS3Provider extends Provider implements ProviderInterface
 
                 $this->s3_client->execute($command);
 
-            } catch (S3Exception $e) {
-                $this->console->writeln("<fg=red>Error while uploading: ($file->getRealpath())</fg=red>");
+            } catch(S3Exception $e) {
+
+                $this->console->writeln("<fg=red>" . $e->getMessage() . "</fg=red>");
 
                 return false;
             }

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -15,7 +15,7 @@ return [
     | Default: false
     |
     */
-    'bypass'    => false,
+    'bypass' => false,
 
     /*
     |--------------------------------------------------------------------------
@@ -28,7 +28,7 @@ return [
     | Supported provider: Amazon S3 (AwsS3)
     |
     */
-    'default'   => 'AwsS3',
+    'default' => 'AwsS3',
 
     /*
     |--------------------------------------------------------------------------
@@ -38,7 +38,7 @@ return [
     | Set your CDN url, [without the bucket name]
     |
     */
-    'url'       => 'https://s3.amazonaws.com',
+    'url' => 'https://s3.amazonaws.com',
 
     /*
     |--------------------------------------------------------------------------
@@ -63,8 +63,9 @@ return [
 	| Of course, examples of configuring each provider platform that is
 	| supported by Laravel is shown below to make development simple.
     |
-    | version: 'latest' means versioning is not enabled, you can replace it
-    |          by your version to enabled it.
+    | Note: Credentials must be set in the .env file:
+    |         AWS_ACCESS_KEY_ID
+    |         AWS_SECRET_ACCESS_KEY
     |
     */
     'providers' => [
@@ -73,14 +74,27 @@ return [
 
             's3' => [
 
-                'version'       => 'latest',
+                /*
+                |--------------------------------------------------------------------------
+                | Web Service Version
+                |--------------------------------------------------------------------------
+                |
+                | The version of the web service to utilize.
+                | http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html#version
+                |
+                */
+                'version' => 'latest',
 
-                'region'        => '',
-
-                'credentials'   => [
-                    'key'    => '',
-                    'secret' => '',
-                ],
+                /*
+                |--------------------------------------------------------------------------
+                | Region to Connect
+                |--------------------------------------------------------------------------
+                |
+                | List of available regions:
+                | http://docs.aws.amazon.com/general/latest/gr/rande.html#awsconfig_region
+                |
+                */
+                'region' => '',
 
                 /*
                 |--------------------------------------------------------------------------
@@ -99,8 +113,9 @@ return [
                 'buckets'       => [
 
                     'bucket-name' => '*',
-                    //        'your-js-bucket-name-here'   =>  ['public/js'],
-                    //        'your-css-bucket-name-here'  =>  ['public/css'],
+                    // examples:
+                    //   'your-js-bucket-name-here'   =>  ['public/js'],
+                    //   'your-css-bucket-name-here'  =>  ['public/css'],
                 ],
 
                 /*
@@ -115,7 +130,7 @@ return [
                 | bucket-owner-read, bucket-owner-full-control, log-delivery-write
                 |
                 */
-                'acl'           => 'public-read',
+                'acl' => 'public-read',
 
                 /*
                 |--------------------------------------------------------------------------
@@ -128,7 +143,7 @@ return [
                 |
                 */
                 'cloudfront'    => [
-                    'use'     => false,
+                    'use' => false,
                     'cdn_url' => ''
                 ],
 
@@ -140,7 +155,7 @@ return [
                 | Add metadata to each S3 file
                 |
                 */
-                'metadata'      => [ ],
+                'metadata' => [ ],
 
                 /*
                 |--------------------------------------------------------------------------
@@ -150,7 +165,7 @@ return [
                 | Add expiry data to file
                 |
                 */
-                'expires'       => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
+                'expires' => gmdate("D, d M Y H:i:s T", strtotime("+5 years")),
 
                 /*
                 |--------------------------------------------------------------------------
@@ -165,10 +180,8 @@ return [
             ],
 
         ],
-//        'cloudflare' => [
-//            'key'       => '',
-//            'secret'    => '',
-//        ],
+
+
 
     ],
     /*

--- a/tests/Vinelab/Cdn/CdnFacadeTest.php
+++ b/tests/Vinelab/Cdn/CdnFacadeTest.php
@@ -27,10 +27,6 @@ class CdnFacadeTest extends TestCase
                     's3' => [
                         'region'  => 'rrrrrrrrrrrgggggggggnnnnn',
                         'version' => 'vvvvvvvvssssssssssnnnnnnn',
-                        'credentials' => [
-                            'key'     => 'keeeeeeeeeeeeeeeeeeeeeeey',
-                            'secret'  => 'ssssssssccccccccccctttttt',
-                        ],
                         'buckets'     => [
                             'bbbuuuucccctttt' => '*',
                         ],

--- a/tests/Vinelab/Cdn/CdnTest.php
+++ b/tests/Vinelab/Cdn/CdnTest.php
@@ -166,7 +166,11 @@ class CdnTest extends TestCase
         $m_s3 = M::mock('Aws\S3\S3Client');
         $m_s3->shouldReceive('factory')
             ->andReturn('Aws\S3\S3Client');
-        $m_s3->shouldReceive('getCommand');
+        $m_command = M::mock('Aws\Command');
+        $m_s3->shouldReceive('getCommand')
+            ->andReturn($m_command);
+        $m_s3->shouldReceive('execute');
+
         $p_aws_s3_provider->setS3Client($m_s3);
 
         $p_aws_s3_provider->shouldReceive('connect')

--- a/tests/Vinelab/Cdn/CdnTest.php
+++ b/tests/Vinelab/Cdn/CdnTest.php
@@ -85,14 +85,10 @@ class CdnTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'region'  => 'rrrrrrrrrrrgggggggggnnnnn',
-                        'version' => 'vvvvvvvvssssssssssnnnnnnn',
-                        'credentials' => [
-                            'key'    => 'keeeeeeeeeeeeeeeeeeeeeeey',
-                            'secret' => 'ssssssssccccccccccctttttt',
-                        ],
+                        'region'  => 'us-standard',
+                        'version' => 'latest',
                         'buckets'     => [
-                            'bbbuuuucccctttt' => '*',
+                            'my-bucket-name' => '*',
                         ],
                         'acl'         => 'public-read',
                         'cloudfront'  => [
@@ -156,6 +152,7 @@ class CdnTest extends TestCase
         $m_spl_file->shouldReceive('getRealPath')
             ->andReturn(__DIR__ . '/AwsS3ProviderTest.php');
 
+        // partial mock
         $p_aws_s3_provider = M::mock('\Vinelab\Cdn\Providers\AwsS3Provider[connect]', array
         (
             $m_console,

--- a/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
@@ -19,7 +19,7 @@ class AwsS3ProviderTest extends TestCase
         parent::setUp();
 
         $this->url       = 'http://www.google.com';
-        $this->cdn_url   = 'http://ZZZZZZZ.www.google.com/public/css/cool/style.css';
+        $this->cdn_url   = 'http://my-bucket-name.www.google.com/public/css/cool/style.css';
         $this->path      = 'public/css/cool/style.css';
         $this->path_url  = 'http://www.google.com/public/css/cool/style.css';
         $this->pased_url = parse_url($this->url);
@@ -72,14 +72,10 @@ class AwsS3ProviderTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'region'  => 'ZZZZZZZ',
-                        'version' => 'EEEEEEE',
-                        'credentials'   => [
-                            'key'     => 'XXXXXXX',
-                            'secret'  => 'YYYYYYY',
-                        ],
-                        'buckets'       => [
-                            'ZZZZZZZ' => '*',
+                        'region'  => 'us-standard',
+                        'version' => 'latest',
+                        'buckets'     => [
+                            'my-bucket-name' => '*',
                         ],
                         'acl'           => 'public-read',
                         'cloudfront'    => [
@@ -109,14 +105,10 @@ class AwsS3ProviderTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'region'  => 'ZZZZZZZ',
-                        'version' => 'EEEEEEE',
-                        'credentials'   => [
-                            'key'    => 'XXXXXXX',
-                            'secret' => 'YYYYYYY',
-                        ],
-                        'buckets'       => [
-                            'ZZZZZZZ' => '*',
+                        'region'  => 'us-standard',
+                        'version' => 'latest',
+                        'buckets'     => [
+                            'my-bucket-name' => '*',
                         ],
                         'acl'           => 'public-read',
                         'cloudfront'    => [
@@ -148,14 +140,10 @@ class AwsS3ProviderTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'region'  => 'ZZZZZZZ',
-                        'version' => 'EEEEEEE',
-                        'credentials'   => [
-                            'key'    => 'XXXXXXX',
-                            'secret' => 'YYYYYYY',
-                        ],
-                        'buckets'       => [
-                            'ZZZZZZZ' => '*',
+                        'region'  => 'us-standard',
+                        'version' => 'latest',
+                        'buckets'     => [
+                            'my-bucket-name' => '*',
                         ],
                         'acl'           => 'public-read',
                         'cloudfront'    => [
@@ -187,13 +175,9 @@ class AwsS3ProviderTest extends TestCase
             'providers' => [
                 'aws' => [
                     's3' => [
-                        'region'  => 'ZZZZZZZ',
-                        'version' => 'EEEEEEE',
-                        'credentials'   => [
-                            'key'    => 'XXXXXXX',
-                            'secret' => 'YYYYYYY',
-                        ],
-                        'buckets'       => [
+                        'region'  => 'us-standard',
+                        'version' => 'latest',
+                        'buckets'     => [
                             '' => '*',
                         ],
                         'acl'           => 'public-read',

--- a/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
@@ -47,7 +47,10 @@ class AwsS3ProviderTest extends TestCase
 
         $this->m_s3 = M::mock('Aws\S3\S3Client');
         $this->m_s3->shouldReceive('factory')->andReturn('Aws\S3\S3Client');
-        $this->m_s3->shouldReceive('getCommand');
+        $m_command = M::mock('Aws\Command');
+        $this->m_s3->shouldReceive('getCommand')
+            ->andReturn($m_command);
+        $this->m_s3->shouldReceive('execute');
         $this->p_awsS3Provider->setS3Client($this->m_s3);
 
         $this->p_awsS3Provider->shouldReceive('connect')->andReturn(true);


### PR DESCRIPTION
- fix the tests that runs for SDK v2 to work for SDK v3
- use `.env` to store the credentials
- upgrade documentation
- upgrade the config file