### PR TITLE
Support for elixir assets

### DIFF
--- a/src/Vinelab/Cdn/CdnFacade.php
+++ b/src/Vinelab/Cdn/CdnFacade.php
@@ -80,6 +80,29 @@ class CdnFacade implements CdnFacadeInterface
         // if asset always append the public/ dir to the path (since the user should not add public/ to asset)
         return $this->generateUrl($path, 'public/');
     }
+	
+	/**
+     * this function will be called from the 'views' using the
+     * 'Cdn' facade {{Cdn::elixir('')}} to convert the elixir generated file path into
+     * it's CDN url.
+     *
+     * @param $path
+     *
+     * @return mixed
+     *
+     * @throws Exceptions\EmptyPathException, \InvalidArgumentException
+     */
+	public function elixir($path)
+    {
+        static $manifest = null;
+        if (is_null($manifest)) {
+            $manifest = json_decode(file_get_contents(public_path('build/rev-manifest.json')), true);
+        }
+        if (isset($manifest[$path])) {
+            return $this->generateUrl('build/' . $manifest[$path], 'public/');
+        }
+        throw new \InvalidArgumentException("File {$path} not defined in asset manifest.");
+    }
 
     /**
      * this function will be called from the 'views' using the


### PR DESCRIPTION
I'm using gulp with Laravel Elixir to build assets to my project. 
To support it on the CDN package, I used the same logic on helpers.php (Illuminate/Foundation/helpers.php).