### PR TITLE
Laravel 5.2 and PHP 7 Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ php:
 matrix:
   allow_failures:
     - php: hhvm
-    - php: 7.0
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 
 matrix:
   allow_failures:
+    - php: hhvm
     - php: 7.0
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "php": ">=5.5.9",
         "illuminate/support": "~5.0",
         "illuminate/config": "~5.0",
-        "symfony/finder": "2.7.*",
-        "symfony/console": "2.7.*",
+        "symfony/finder": "2.8.*|3.0.*",
+        "symfony/console": "2.8.*|3.0.*",
         "aws/aws-sdk-php": "~3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.5.9",
         "illuminate/support": "~5.0",
         "illuminate/config": "~5.0",
         "symfony/finder": "2.7.*",


### PR DESCRIPTION
This pull request updates the composer dependencies to sync with Laravel 5.2's dependencies. It raises the required PHP version to 5.5.9. 

Also, for Travis CI, PHP 7 is no longer an allowed failure.

**Suggest creating a new Laravel 5.2 branch for compatibility reasons.**