### PR TITLE
lowercased the D in MetaData to follow AWS guide

### DIFF
--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -211,7 +211,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
 
                         'ACL' => $this->acl,
                         'CacheControl' => $this->default['providers']['aws']['s3']['cache-control'],
-                        'MetaData' => $this->default['providers']['aws']['s3']['metadata'],
+                        'Metadata' => $this->default['providers']['aws']['s3']['metadata'],
                         'Expires' => $this->default['providers']['aws']['s3']['expires'],
                     ]);
 //                var_dump(get_class($command));exit();


### PR DESCRIPTION
The parameter name should be `Metadata` and not `MetaData` according to
http://docs.aws.amazon.com/aws-sdk-php/v2/guide/service-s3.html