### PR TITLE
make buildDir for Cdn::elixir customizable #107

### DIFF
--- a/src/Vinelab/Cdn/CdnFacade.php
+++ b/src/Vinelab/Cdn/CdnFacade.php
@@ -87,19 +87,20 @@ class CdnFacade implements CdnFacadeInterface
      * it's CDN url.
      *
      * @param $path
+     * @param string $buildDir
      *
      * @return mixed
      *
      * @throws Exceptions\EmptyPathException, \InvalidArgumentException
      */
-	public function elixir($path)
+	public function elixir($path, $buildDir = 'build')
     {
         static $manifest = null;
         if (is_null($manifest)) {
-            $manifest = json_decode(file_get_contents(public_path('build/rev-manifest.json')), true);
+            $manifest = json_decode(file_get_contents(public_path("$buildDir/rev-manifest.json")), true);
         }
         if (isset($manifest[$path])) {
-            return $this->generateUrl('build/' . $manifest[$path], 'public/');
+            return $this->generateUrl($buildDir . '/' . $manifest[$path], 'public/');
         }
         throw new \InvalidArgumentException("File {$path} not defined in asset manifest.");
     }


### PR DESCRIPTION
Hi! This PR change `elixir` method and make build directory name customizable, using `buildDir` argument.  