### PR TITLE
Allow set target root CDN directory  #103

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,13 @@ Set the CDN URL:
 'url' => 'https://s3.amazonaws.com',
 ```
 
+##### CDN Base Directory
+Set CDN base dir path, if null, upload assets into bucket root. 
+```php
+'cdn_base_dir' => null,
+```
+Example: 'myapp1/assets', then you can access assets by url like https://my-bucket.name/myapp1/assets/file.jpg
+
 ##### HTTP
 
 Set the HTTP parameters:

--- a/src/Vinelab/Cdn/CdnFacade.php
+++ b/src/Vinelab/Cdn/CdnFacade.php
@@ -150,7 +150,9 @@ class CdnFacade implements CdnFacadeInterface
 
         // remove slashes from begging and ending of the path
         // and append directories if needed
-        $clean_path = $prepend.$this->helper->cleanPath($path);
+        $clean_path = $this->helper->getCdnFilePath(
+            $prepend.$this->helper->cleanPath($path)
+        );
 
         // call the provider specific url generator
         return $this->provider->urlGenerator($clean_path);

--- a/src/Vinelab/Cdn/CdnHelper.php
+++ b/src/Vinelab/Cdn/CdnHelper.php
@@ -112,4 +112,35 @@ class CdnHelper implements CdnHelperInterface
     {
         return rtrim(ltrim($path, '/'), '/');
     }
+
+    /**
+     * Make path to local file copy on CDN, using cdn_base_dir
+     * @param string $localPath
+     * @return string
+     */
+    public function getCdnFilePath($localPath)
+    {
+        $baseDir = null;
+        $cfg = $this->getConfigurations();
+        $localPath = $this->normalizePath($localPath);
+
+        if (isset($cfg['cdn_base_dir'])) {
+            $baseDir = $cfg['cdn_base_dir'];
+        }
+
+        if (null === $baseDir) {
+            return $localPath;
+        }
+
+        return $this->cleanPath($baseDir).'/'.$this->cleanPath($localPath);
+    }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    private function normalizePath($path)
+    {
+        return str_replace('\\', '/', $path);
+    }
 }

--- a/src/Vinelab/Cdn/Contracts/CdnHelperInterface.php
+++ b/src/Vinelab/Cdn/Contracts/CdnHelperInterface.php
@@ -18,4 +18,6 @@ interface CdnHelperInterface
     public function startsWith($haystack, $needle);
 
     public function cleanPath($path);
+
+    public function getCdnFilePath($localPath);
 }

--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -204,7 +204,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
                         // the bucket name
                         'Bucket' => $this->getBucket(),
                         // the path of the file on the server (CDN)
-                        'Key' => str_replace('\\', '/', $file->getPathName()),
+                        'Key' => $this->cdn_helper->getCdnFilePath($file->getPathName()),
                         // the path of the path locally
                         'Body' => fopen($file->getRealPath(), 'r'),
                         // the permission of the file
@@ -214,8 +214,6 @@ class AwsS3Provider extends Provider implements ProviderInterface
                         'Metadata' => $this->default['providers']['aws']['s3']['metadata'],
                         'Expires' => $this->default['providers']['aws']['s3']['expires'],
                     ]);
-//                var_dump(get_class($command));exit();
-
 
                     $this->s3_client->execute($command);
                 } catch (S3Exception $e) {
@@ -395,7 +393,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
         }
 
         $assets->transform(function($item, $key) use(&$filesOnAWS) {
-            $fileOnAWS = $filesOnAWS->get(str_replace('\\', '/', $item->getPathName()));
+            $fileOnAWS = $filesOnAWS->get($this->cdn_helper->getCdnFilePath($item->getPathName()));
 
             //select to upload files that are different in size AND last modified time.
             if(!($item->getMTime() === $fileOnAWS['LastModified']) && !($item->getSize() === $fileOnAWS['Size'])) {

--- a/src/config/cdn.php
+++ b/src/config/cdn.php
@@ -42,6 +42,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | CDN BASE DIRECTORY
+    |--------------------------------------------------------------------------
+    |
+    | Set CDN base dir path, if null, upload into bucket root
+    | Example: 'myapp1/assets', then you can access assets
+    | by url like https://my-bucket.name/myapp1/assets/file.jpg
+    |
+    */
+    'cdn_base_dir' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Threshold
     |--------------------------------------------------------------------------
     |

--- a/tests/Vinelab/Cdn/CdnFacadeTest.php
+++ b/tests/Vinelab/Cdn/CdnFacadeTest.php
@@ -13,6 +13,8 @@ use Mockery as M;
  */
 class CdnFacadeTest extends TestCase
 {
+    const CDN_BASE_DIR = 'base';
+
     public function setUp()
     {
         parent::setUp();
@@ -21,6 +23,7 @@ class CdnFacadeTest extends TestCase
             'bypass' => false,
             'default' => 'AwsS3',
             'url' => 'https://s3.amazonaws.com',
+            'cdn_base_dir' => self::CDN_BASE_DIR,
             'threshold' => 10,
             'providers' => [
                 'aws' => [
@@ -66,6 +69,7 @@ class CdnFacadeTest extends TestCase
         $this->helper->shouldReceive('getConfigurations')->once()->andReturn($configuration_file);
         $this->helper->shouldReceive('cleanPath')->andReturn($this->asset_path);
         $this->helper->shouldReceive('startsWith')->andReturn(true);
+        $this->helper->shouldReceive('getCdnFilePath')->andReturn(self::CDN_BASE_DIR.'/'.$this->asset_path);
 
         $this->validator = new \Vinelab\Cdn\Validators\CdnFacadeValidator();
 

--- a/tests/Vinelab/Cdn/CdnHelperTest.php
+++ b/tests/Vinelab/Cdn/CdnHelperTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Vinelab\Cdn\Tests;
+
+use Illuminate\Config\Repository;
+use Mockery as M;
+use Vinelab\Cdn\CdnHelper;
+
+/**
+ * Class CdnHelperTest.
+ * @category Test
+ * @author Maksim Khodyrev <maximkou@gmail.com>
+ */
+class CdnHelperTest extends \PHPUnit_Framework_TestCase
+{
+    const CDN_BASE_DIR = 'base';
+
+    /**
+     * @dataProvider dpGetCdnFilePath
+     * @param string $localPath
+     * @param string $cdnPath
+     */
+    public function testGetCdnFilePath($localPath, $cdnPath)
+    {
+        $helper = new CdnHelper(
+            new Repository([
+                'cdn' => $this->getCdnConfig()
+            ])
+        );
+
+        $this->assertEquals(
+            $cdnPath,
+            $helper->getCdnFilePath($localPath)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function dpGetCdnFilePath()
+    {
+        return [
+            [
+                'public/image.png',
+                self::CDN_BASE_DIR.'/public/image.png',
+            ],
+            [
+                '/public/image.png',
+                self::CDN_BASE_DIR.'/public/image.png',
+            ],
+            [
+                'image.png',
+                self::CDN_BASE_DIR.'/image.png',
+            ]
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    private function getCdnConfig()
+    {
+        return [
+            'bypass' => false,
+            'default' => 'AwsS3',
+            'url' => 'https://s3.amazonaws.com',
+            'cdn_base_dir' => self::CDN_BASE_DIR,
+            'threshold' => 10,
+            'providers' => [
+                'aws' => [
+                    's3' => [
+                        'region' => 'us-standard',
+                        'version' => 'latest',
+                        'http' => null,
+                        'buckets' => [
+                            'my-bucket-name' => '*',
+                        ],
+                        'acl' => 'public-read',
+                        'cloudfront' => [
+                            'use' => false,
+                            'cdn_url' => '',
+                        ],
+                        'metadata' => [],
+
+                        'expires' => gmdate('D, d M Y H:i:s T', strtotime('+5 years')),
+
+                        'cache-control' => 'max-age=2628000',
+                    ],
+                ],
+            ],
+            'include' => [
+                'directories' => [__DIR__],
+                'extensions' => [],
+                'patterns' => [],
+            ],
+            'exclude' => [
+                'directories' => [],
+                'files' => [],
+                'extensions' => [],
+                'patterns' => [],
+                'hidden' => true,
+            ],
+        ];
+    }
+}

--- a/tests/Vinelab/Cdn/CdnTest.php
+++ b/tests/Vinelab/Cdn/CdnTest.php
@@ -14,6 +14,8 @@ use Mockery as M;
  */
 class CdnTest extends TestCase
 {
+    const CDN_BASE_DIR = 'base';
+
     public function setUp()
     {
         parent::setUp();
@@ -81,6 +83,7 @@ class CdnTest extends TestCase
             'bypass' => false,
             'default' => 'AwsS3',
             'url' => 'https://s3.amazonaws.com',
+            'cdn_base_dir' => self::CDN_BASE_DIR,
             'threshold' => 10,
             'providers' => [
                 'aws' => [
@@ -144,6 +147,7 @@ class CdnTest extends TestCase
         $m_validator->shouldReceive('validate');
 
         $m_helper = M::mock('Vinelab\Cdn\CdnHelper');
+        $m_helper->shouldReceive('getCdnFilePath');
 
         $m_spl_file = M::mock('Symfony\Component\Finder\SplFileInfo');
         $m_spl_file->shouldReceive('getPathname')

--- a/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
+++ b/tests/Vinelab/Cdn/Providers/AwsS3ProviderTest.php
@@ -14,6 +14,8 @@ use Mockery as M;
  */
 class AwsS3ProviderTest extends TestCase
 {
+    const CDN_BASE_DIR = 'base';
+
     public function setUp()
     {
         parent::setUp();
@@ -33,6 +35,7 @@ class AwsS3ProviderTest extends TestCase
         $this->m_helper = M::mock('Vinelab\Cdn\CdnHelper');
         $this->m_helper->shouldReceive('parseUrl')
                        ->andReturn($this->pased_url);
+        $this->m_helper->shouldReceive('getCdnFilePath');
 
         $this->m_spl_file = M::mock('Symfony\Component\Finder\SplFileInfo');
         $this->m_spl_file->shouldReceive('getPathname')->andReturn('vinelab/cdn/tests/Vinelab/Cdn/AwsS3ProviderTest.php');
@@ -103,6 +106,7 @@ class AwsS3ProviderTest extends TestCase
         $configurations = [
             'default' => 'AwsS3',
             'url' => 'https://s3.amazonaws.com',
+            'cdn_base_dir' => self::CDN_BASE_DIR,
             'threshold' => 10,
             'providers' => [
                 'aws' => [


### PR DESCRIPTION
Thanks for the good tool! This PR add #103 feature.

Prefix configured using `cdn_base_dir` config item (I read your conversation with @bubenkoff, but adding new option is really best solution).