### PR TITLE
Make sure that all the objects are retrieved. The listObjects functio…

### DIFF
--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -384,7 +384,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
             'Bucket' => $this->getBucket()
         ]);
 
-        if ((is_array($files) && !$contents['Contents']) || !$files->current()) {
+        if (empty($files) || !$files->current()) {
             //no files on bucket. lets upload everything found.
             return $assets;
         }

--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -380,16 +380,16 @@ class AwsS3Provider extends Provider implements ProviderInterface
     {
         $filesOnAWS = new Collection([]);
 
-        $files = $this->s3_client->listObjects([
-            'Bucket' => $this->getBucket(),
+        $files = $this->s3_client->getIterator('ListObjects', [
+            'Bucket' => $this->getBucket()
         ]);
 
-        if (!$files['Contents']) {
+        if (!$files->current()) {
             //no files on bucket. lets upload everything found.
             return $assets;
         }
 
-        foreach($files['Contents'] as $file) {
+        foreach($files as $file) {
             $a = ['Key' => $file['Key'], "LastModified" => $file['LastModified']->getTimestamp(), 'Size' => $file['Size']];
             $filesOnAWS->put($file['Key'], $a);
         }

--- a/src/Vinelab/Cdn/Providers/AwsS3Provider.php
+++ b/src/Vinelab/Cdn/Providers/AwsS3Provider.php
@@ -384,7 +384,7 @@ class AwsS3Provider extends Provider implements ProviderInterface
             'Bucket' => $this->getBucket()
         ]);
 
-        if (!$files->current()) {
+        if ((is_array($files) && !$contents['Contents']) || !$files->current()) {
             //no files on bucket. lets upload everything found.
             return $assets;
         }


### PR DESCRIPTION
Make sure that all the objects are retrieved. The listObjects function is limited to 1000 objects so if the bucket contains more than those objects then some of them will not be retrieved when using the listObjects function. An iterator is used instead as suggested in the AmazonS3 developer guide: http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingObjectKeysUsingPHP.html